### PR TITLE
Add expiry option to setSaveHandler()

### DIFF
--- a/src/MemCachier/MemcacheSASL.php
+++ b/src/MemCachier/MemcacheSASL.php
@@ -633,10 +633,11 @@ class MemcacheSASL
      * session_start();
      * $_SESSION['hello'] = 'world';
      *
+     * @param int $expiration the time in seconds when the session should expire (0 for never).
      * @access public
      * @return void
      */
-    public function setSaveHandler()
+    public function setSaveHandler($expiration = 0)
     {
         session_set_save_handler(
             function($savePath, $sessionName){ // open
@@ -646,8 +647,8 @@ class MemcacheSASL
             function($sessionId){ // read
                 return $this->get($sessionId);
             },
-            function($sessionId, $data){ // write
-                return $this->set($sessionId, $data);
+            function($sessionId, $data) use($expiration) { // write
+                return $this->set($sessionId, $data, $expiration);
             },
             function($sessionId){ // destroy
                 $this->delete($sessionId);


### PR DESCRIPTION
Otherwise sessions will last forever and the memcached server will fill up.
This uses the existing expiry code on the set() method and still defaults to zero.